### PR TITLE
Fixing Chef deprecated warning

### DIFF
--- a/providers/metric_collectd.rb
+++ b/providers/metric_collectd.rb
@@ -67,7 +67,7 @@ def proc_metric(new_resource)
   # hashes to keep from breaking existing install
 
   node["monitoring"]["procs"] ||= {}
-  node["monitoring"]["procs"][new_resource.proc_name] = new_resource.proc_regex
+  node.set["monitoring"]["procs"][new_resource.proc_name] = new_resource.proc_regex
 
   matches = node["monitoring"]["procs"].reject {|k,v| v.nil? }
   process = node["monitoring"]["procs"].select {|k,v| v.nil? }
@@ -246,7 +246,7 @@ def mysql_metric(new_resource)
   options.merge({"MasterStats" => false })
 
   node["monitoring"]["dbs"] ||= {}
-  node["monitoring"]["dbs"][new_resource.db] = options
+  node.set["monitoring"]["dbs"][new_resource.db] = options
 
   collectd_plugin "mysql" do
     template "collectd-plugin-mysql.conf.erb"


### PR DESCRIPTION
```
WARN: Setting attributes without specifying a precedence is deprecated and will be
removed in Chef 11.0. To set attributes at normal precedence, change code like:
`node["key"] = "value"` # Not this
to:
`node.set["key"] = "value"` # This
```
